### PR TITLE
スクリーンショットを animation GIF 化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in gnawrnip.gemspec
 gemspec
+
+group :test do
+  gem 'poltergeist'
+  gem 'sinatra'
+end

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'sinatra'
-gem 'capybara', '~> 2.1.0'
-gem 'rspec'
-gem 'turnip'
-gem 'turnip_formatter'
-gem 'gnawrnip'
-gem 'poltergeist'

--- a/gnawrnip.gemspec
+++ b/gnawrnip.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'capybara', "~> 2.1"
-  spec.add_dependency 'turnip_formatter', '~> 0.1.0'
+  spec.add_dependency 'turnip_formatter', '~> 0.1.2'
+  spec.add_dependency 'rmagick'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'

--- a/lib/gnawrnip.rb
+++ b/lib/gnawrnip.rb
@@ -1,6 +1,9 @@
 require "gnawrnip/version"
 
 module Gnawrnip
+  require 'gnawrnip/ext/capybara/session'
+  require 'gnawrnip/animation'
+  require 'gnawrnip/screenshot'
   require 'gnawrnip/step_screenshot'
   require 'gnawrnip/rspec'
 end

--- a/lib/gnawrnip/animation.rb
+++ b/lib/gnawrnip/animation.rb
@@ -1,0 +1,37 @@
+require 'gnawrnip/screenshot'
+require 'RMagick'
+require 'base64'
+
+module Gnawrnip
+  class Animation
+    class << self
+      def reset!
+        frames.clear
+      end
+
+      def frames
+        @frames ||= []
+      end
+
+      def add_frame
+        image = Screenshot.take
+        frames << image
+      end
+
+      def generate
+        gif = Tempfile.new(['gnawrnip_animation', '.gif'])
+        image.write(gif.path)
+        Base64.encode64(gif.read)
+      end
+
+      private
+
+      def image
+        paths = frames.map(&:path)
+        images = Magick::ImageList.new(*paths)
+        images.delay = 50
+        images
+      end
+    end
+  end
+end

--- a/lib/gnawrnip/ext/capybara/session.rb
+++ b/lib/gnawrnip/ext/capybara/session.rb
@@ -1,0 +1,20 @@
+require 'capybara/session'
+
+module Capybara
+  class Session
+    SAVE_SCREENSHOT_METHODS = [
+      :attach_file, :check, :choose, :click_link_or_button, :click_button,
+      :click_link, :fill_in, :select, :uncheck, :unselect, :click_on,
+      :evaluate_script, :visit
+    ]
+
+    SAVE_SCREENSHOT_METHODS.each do |method|
+      alias_method "after_hook_#{method}".to_sym, method
+
+      define_method method do |*args, &block|
+        send("after_hook_#{method}", *args, &block)
+        Gnawrnip::Animation.add_frame
+      end
+    end
+  end
+end

--- a/lib/gnawrnip/rspec.rb
+++ b/lib/gnawrnip/rspec.rb
@@ -3,13 +3,14 @@ require 'tempfile'
 require 'base64'
 
 RSpec.configure do |config|
-  config.after do
+  config.before(:each, turnip: true) do
+    Gnawrnip::Animation.reset!
+  end
+
+  config.after(:each, turnip: true) do
     if example.exception
-      temp = Tempfile.new(['gnawrnip', '.png'])
-      save_screenshot(temp.path)
-      example.metadata[:turnip] ||= {}
-      example.metadata[:turnip][:screenshot] = Base64.encode64(File.read(temp.path))
-      temp.close!
+      example.metadata[:gnawrnip] = {}
+      example.metadata[:gnawrnip][:screenshot] = Gnawrnip::Animation.generate
     end
   end
 end

--- a/lib/gnawrnip/screenshot.rb
+++ b/lib/gnawrnip/screenshot.rb
@@ -1,0 +1,29 @@
+require 'tempfile'
+require 'capybara'
+
+module Gnawrnip
+  class Screenshot
+    class << self
+
+      #
+      # Screenshot of current capybara session
+      #
+      # @example
+      #   image = Gnawrnip::Screenshot.take
+      #
+      # @return  [Tempfile]  Image of screenshot
+      #
+      def take
+        tempfile = Tempfile.new(['gnawrnip', '.png'])
+        session.save_screenshot(tempfile.path)
+        tempfile
+      end
+
+      private
+
+      def session
+        Capybara.current_session
+      end
+    end
+  end
+end

--- a/lib/gnawrnip/step_screenshot.rb
+++ b/lib/gnawrnip/step_screenshot.rb
@@ -3,11 +3,11 @@ require 'turnip_formatter/step/failure'
 module Gnawrnip
   module StepScreenshot
     #
-    # @param  [String]  png_file  base64 encoded
+    # @param  [String]  gif_file  base64 encoded
     #
-    def self.build(png_file)
-      img = '<img src="data:image/png;base64,'
-      img += png_file
+    def self.build(gif_base64)
+      img = '<img src="data:image/gif;base64,'
+      img += gif_base64
       img += '" style="width: 90%; border: 2px solid black;" />'
       img
     end
@@ -15,5 +15,5 @@ module Gnawrnip
 end
 
 TurnipFormatter::Step::Failure.add_template :screenshot, Gnawrnip::StepScreenshot do
-  example.metadata[:turnip][:screenshot]
+  example.metadata[:gnawrnip][:screenshot]
 end

--- a/spec/gnawrnip/animation_spec.rb
+++ b/spec/gnawrnip/animation_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+require 'gnawrnip/animation'
+
+module Gnawrnip
+  describe Animation do
+    before do
+      Animation.reset!
+      Animation.add_frame
+      Animation.add_frame
+    end
+
+    describe '.add_frame' do
+      subject { Animation.frames }
+      it { should have(2).elements }
+    end
+
+    describe '.reset!' do
+      before { Animation.reset! }
+      subject { Animation.frames }
+      it { should be_empty }
+    end
+
+    describe '.generate' do
+      before do
+        ::Magick::ImageList.any_instance.stub(:initialize) do |*filenames|
+          @file_length = filenames.length
+        end
+        ::Magick::ImageList.any_instance.stub(:delay=)
+        ::Magick::ImageList.any_instance.stub(:write) do |path|
+          File.write(path, @file_length.to_s)
+        end
+      end
+
+      subject { Animation.generate }
+      it 'should be base64 encoded string for each files.' do
+        should == "Mg==\n"
+      end
+    end
+  end
+end

--- a/spec/gnawrnip/rspec_spec.rb
+++ b/spec/gnawrnip/rspec_spec.rb
@@ -3,8 +3,11 @@ require 'gnawrnip/rspec'
 
 module Gnawrnip
   describe 'Rspec' do
+    before do
+      Gnawrnip::Animation.should_receive(:generate).and_return('aiueo')
+    end
+
     let(:example) do
-      group = ::RSpec::Core::ExampleGroup.describe('Feature')
       example = group.example('example', {}) { expect(true).to be_false }
       group.run(
         Class.new do
@@ -16,8 +19,24 @@ module Gnawrnip
       example
     end
 
-    it 'should save screen shot at error' do
-      expect(example.metadata[:turnip][:screenshot]).to eq "c2NyZWVuc2hvdA==\n"
+    context '"turnip" spec group' do
+      let(:group) do
+        ::RSpec::Core::ExampleGroup.describe('Feature', turnip: true)
+      end
+
+      it 'should save screen shot at error' do
+        expect(example.metadata[:gnawrnip][:screenshot]).to eq 'aiueo'
+      end
+    end
+
+    context 'Not "turnip" spec group' do
+      let(:group) do
+        ::RSpec::Core::ExampleGroup.describe('Feature')
+      end
+
+      it 'should not save screen shot' do
+        expect(example.metadata).not_to include(:gnawrnip)
+      end
     end
   end
 end

--- a/spec/gnawrnip/screenshot_spec.rb
+++ b/spec/gnawrnip/screenshot_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'gnawrnip/screenshot'
+
+module Gnawrnip
+  describe Screenshot do
+    describe '.take' do
+      subject { Screenshot.take.read }
+
+      # see GnawrnipTestSession::save_screenshot
+      it { should == 'screenshot' }
+    end
+  end
+end

--- a/spec/gnawrnip/step_screenshot_spec.rb
+++ b/spec/gnawrnip/step_screenshot_spec.rb
@@ -13,7 +13,7 @@ module Gnawrnip
 
     describe '.build' do
       subject { template.build('aiueo') }
-      it { should match %r{<img src="data:image/png;base64,aiueo"} }
+      it { should match %r{<img src="data:image/gif;base64,aiueo"} }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,16 +2,22 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'gnawrnip'
+require 'capybara'
 
-RSpec.configure do |config|
-  config.include(
-    Module.new do
-      # stub Capybara::Session.save_screenshot
-      def save_screenshot(file_path)
-        File.open(file_path, 'w') do |fp|
-          fp.print 'screenshot'
-        end
-      end
+class GnawrnipTestSession
+  def save_screenshot(file_path)
+    File.open(file_path, 'w') do |fp|
+      fp.print 'screenshot'
     end
-  )
+  end
+
+  def method_missing(name, *args, &block)
+    # nooooooop
+  end
+end
+
+module Capybara
+  def self.current_session
+    GnawrnipTestSession.new
+  end
 end


### PR DESCRIPTION
## 目的

エラー出た瞬間の画像が見れるのはいいが、
時々「お前なんでその画面に居るの」みたいなシチュエーションがあって、
そういう時ってだいたい画面見ながら動かしてると再現しなくて悲しいので
道程も見たいなってことで
## 手段

画面が更新されそうなアクションの直後に `save_screenshot()` を発動する

``` ruby
module Capybara
  class Session
    SAVE_SCREENSHOT_METHODS = [
      :attach_file, :check, :choose, :click_link_or_button, :click_button,
      :click_link, :fill_in, :select, :uncheck, :unselect, :click_on,
      :evaluate_script, :visit
    ]

    SAVE_SCREENSHOT_METHODS.each do |method|
      alias_method "after_hook_#{method}".to_sym, method

      define_method method do |*args, &block|
        send("after_hook_#{method}", *args, &block)
        temp = Tempfile.new(['gnawrnip', '.png'])
        save_screenshot(temp.path)

        Gnawrnip::Animation.add_frame(temp.path)
      end
    end
  end
end
```

みたいな感じかな。(Ruby 2.0 だと Module#prepend が使えるが、まあいい…)
