### PR TITLE
スクリーンショットのサイズについて

### DIFF
--- a/example/spec/spec_helper.rb
+++ b/example/spec/spec_helper.rb
@@ -21,9 +21,10 @@ Capybara.default_driver = :poltergeist
 Capybara.javascript_driver = :selenium
 
 Gnawrnip.configure do |c|
-  c.frame_interval = 1000 # milliseconds
   c.photographer_driver = :js
-  # c.photographer_driver = :rmagick
+  #c.photographer_driver = :rmagick
+  c.frame_interval = 1000 # milliseconds
+  c.frame_size = [640, 360] # width, height
 end
 
 Gnawrnip.ready!

--- a/lib/gnawrnip.rb
+++ b/lib/gnawrnip.rb
@@ -10,6 +10,7 @@ module Gnawrnip
   class << self
     attr_accessor :photographer_driver
     attr_accessor :frame_interval
+    attr_accessor :frame_size
 
     def configure
       yield self
@@ -33,6 +34,7 @@ module Gnawrnip
 end
 
 Gnawrnip.configure do |c|
-  c.frame_interval = 1000
   c.photographer_driver = :js
+  c.frame_interval = 1000
+  c.frame_size = nil
 end

--- a/lib/gnawrnip/rmagick/photographer.rb
+++ b/lib/gnawrnip/rmagick/photographer.rb
@@ -28,9 +28,16 @@ module Gnawrnip::RMagick
 
     def photo_creator(images)
       paths = images.map(&:path)
-      image = ::Magick::ImageList.new(*paths)
-      image.delay = Gnawrnip.frame_interval / 10.0
-      image
+      photos = ::Magick::ImageList.new(*paths)
+
+      photos.delay = Gnawrnip.frame_interval / 10.0
+      unless Gnawrnip.frame_size.nil?
+        photos.each do |p|
+          p.scale!(*Gnawrnip.frame_size)
+        end
+      end
+
+      photos
     end
   end
 end

--- a/lib/gnawrnip/step_screenshot.rb
+++ b/lib/gnawrnip/step_screenshot.rb
@@ -40,7 +40,7 @@ module TurnipFormatter
         ul.steps {
             div.screenshot {
                > img {
-                 width: 90%;
+                 max-width: 90%;
                  border: 2px solid black;
                }
            }


### PR DESCRIPTION
テスト実行時のディスプレイの環境によってスクリーンショットのサイズが違ってて(まあそれはいいんだけど)
例えば縦ディスプレイで selenium-webdriver とか使うと、スクリーンショットが縦長になって report が見づらくなる。
どんな環境でもある程度のサイズに抑えておきたい
## 方法
- リサイズする(RMagick)
- ブラウザのうぃんどうサイズを変更する
  - poltergeist だったらすぐいけた気がする
  - selenium だとどうするんだろう。

gnawrnip 自体は capybara driver が poltergeist でも selenium-webdriver でもどっちでもいいようにしたいので(もしかしたら capybara-webkit でも普通に動くはず)、
あまり gnarwnip の中からはそこらへんにアクセスしたくない。

テスト作成者が既にブラウザのサイズを抑えてくれている場合もあるので
1. 抑えるサイズ内に既に収まっていたらそのままで
2. はみ出してたら RMagick とかでリサイズ

ぐらいでいいか
