### PR TITLE
Exception occured in message "The IDAT chunk should not be empty"

### DIFF
--- a/lib/gnawrnip/photographer.rb
+++ b/lib/gnawrnip/photographer.rb
@@ -14,7 +14,7 @@ module Gnawrnip
     # Close tempfiles.
     #
     def discard!
-      frames.each(&:close!)
+      frames.compact.each(&:close!)
       reset!
     end
 

--- a/lib/gnawrnip/screenshot.rb
+++ b/lib/gnawrnip/screenshot.rb
@@ -32,9 +32,15 @@ module Gnawrnip
         rescue Capybara::NotSupportedByDriverError => e
           raise e
         rescue => e
-          raise e if (Time.now - start_time) >= wait_second
-          sleep(0.3)
-          retry
+          if (Time.now - start_time) < wait_second
+            sleep(0.3)
+            retry
+          end
+
+          $stderr.puts "WARNING: Timeout!! Can't take screenshot"
+          $stderr.puts "  #{e}"
+
+          nil
         end
       end
 

--- a/spec/gnawrnip/screenshot_spec.rb
+++ b/spec/gnawrnip/screenshot_spec.rb
@@ -32,11 +32,11 @@ module Gnawrnip
           end
 
           it 'should raise Timeout Error' do
-            expect {
-              Capybara.using_wait_time 2 do
-                Screenshot.take
-              end
-            }.to raise_error Timeout::Error
+            screenshot = Capybara.using_wait_time 2 do
+              Screenshot.take
+            end
+
+            expect(screenshot).to be_nil
           end
         end
       end


### PR DESCRIPTION
## 経緯

ブラウザ開いた直後だったり、何かしらのタイミングで `save_screenshot` すると
空?の png ファイルができて、そいつを OilyPng (ChunkyPng) で扱おうとエラー

![untitled](https://f.cloud.github.com/assets/124713/2252824/283af51a-9db0-11e3-95b2-3e8a2b2d0bc7.png)
## 対策

空ファイルだったらどうにかする
