### PR TITLE
Change timing of take a screenshot.

### DIFF
--- a/lib/gnawrnip/ext/capybara/session.rb
+++ b/lib/gnawrnip/ext/capybara/session.rb
@@ -25,7 +25,7 @@ module Capybara
       alias_method "after_hook_#{method}".to_sym, method
 
       define_method method do |*args, &block|
-        Gnawrnip.photographer.take_shot
+        Gnawrnip.photographer.take_shot if current_url != 'about:blank'
         send("after_hook_#{method}", *args, &block)
       end
     end

--- a/lib/gnawrnip/rspec.rb
+++ b/lib/gnawrnip/rspec.rb
@@ -22,6 +22,10 @@ RSpec.configure do |config|
       Gnawrnip.photographer.take_shot
       screenshots = Gnawrnip.photographer.frames.compact
       example.metadata[:gnawrnip][:screenshot] = screenshots
+    else
+      Gnawrnip.photographer.frames.compact.each do |fp|
+        fp.close!
+      end
     end
   end
 end

--- a/lib/gnawrnip/step_screenshot.rb
+++ b/lib/gnawrnip/step_screenshot.rb
@@ -47,7 +47,7 @@ module Gnawrnip
 
     def single_image(file)
       text = '<div class="screenshot">'
-      text += develop([file.path])
+      text += develop([file])
       text + '</div>'
     end
 


### PR DESCRIPTION
## Motivation

Take screenshot too.
- Hypertrophy of the report file size
- Decrease in execution speed

It should kept to minimum necessary take screenshots.
## Solution
### Current

Before process of Capybara::Session::NODE_METHODS
- [lib/gnawrnip/ext/capybara/session.rb](https://github.com/gongo/gnawrnip/blob/cfb6d3db348a6f3e75f40bcacf93acb176861aba/lib/gnawrnip/ext/capybara/session.rb#L13-L14)
- https://github.com/jnicklas/capybara/blob/2.4.1/lib/capybara/session.rb#L27-L38
### New timing 1

Only verification process **immediately after** the action process.
- verification process
  - `has_text?`, `has_select?`, etc..
- action process
  - `click`, `fill_in`, etc...
### New timing 2

Taking every **step**
